### PR TITLE
Added style prop to the image

### DIFF
--- a/lib/imagePreloader.jsx
+++ b/lib/imagePreloader.jsx
@@ -79,6 +79,7 @@ var ImagePreloader = React.createClass({
 
     render: function () {
         return (<img
+					style={this.props.style}
                     className={this.props.className || ''}
                     src={this.state.hasLoaded ? this.props.src : this.props.fallback}
                 />);


### PR DESCRIPTION
Created to solve #1. Basically any props you add to the image-preloader component will be added to the child <img>, allowing you to give the image a fixed height, for example:

``` javascript
var Image = require('react-image-preloader');
<Image 
             src="largeImage.jpg"
             fallback="smallImage.jpg"
             style={{
                 display: "inline-block",
                 height: 342,
                 width: 245
             }}
/>
```
